### PR TITLE
fixed bug in Terminate Task reason for failure parameter

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -838,8 +838,7 @@ public class WorkflowExecutor {
                     (String)
                             terminateTask
                                     .get()
-                                    .getWorkflowTask()
-                                    .getInputParameters()
+                                    .getInputData()
                                     .get(Terminate.getTerminationReasonParameter());
             if (StringUtils.isBlank(reason)) {
                 reason =


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

TerminationReason was not getting parameterised, hence fetching parameterised TerminationReason.

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
